### PR TITLE
Fix printing of status while booting

### DIFF
--- a/lib/fastlane/plugin/mango/helper/mango_helper.rb
+++ b/lib/fastlane/plugin/mango/helper/mango_helper.rb
@@ -232,7 +232,13 @@ module Fastlane
             UI.success('Your container is ready to work')
             return true
           end
-          UI.important("Container status: #{@container.json['State']['Status']}")
+          
+          if @container.json['State']['Health']
+            UI.important("Container status: #{@container.json['State']['Health']['Status']}")
+          else
+            UI.important("Container status: #{@container.json['State']['Status']}")
+          end
+
           sleep sleep_interval
         end
         UI.important("The Container failed to load after '#{timeout}' seconds timeout. Reason: '#{@container.json['State']['Status']}'")


### PR DESCRIPTION
We ddin't respect if there was a healh state in the booting container or not.
This change will also check for that if it prints to give a more informative log.