### PR TITLE
Return container ID

### DIFF
--- a/lib/fastlane/plugin/mango/helper/docker_commander.rb
+++ b/lib/fastlane/plugin/mango/helper/docker_commander.rb
@@ -20,6 +20,7 @@ module Fastlane
         # interested in the last line, since it contains the id of the created container.
         UI.important("Attaching #{ENV['PWD']} to the docker container")
         output = Actions.sh("docker run -v $PWD:/root/tests --privileged -t -d #{emulator_args} #{docker_name} #{docker_image}").chomp
+        output.split("\n").last
       end
 
       def self.stop_container(container_name:)


### PR DESCRIPTION
This got removed during refactoring. We need it to return the container ID to the main helper