### PR TITLE
Perform docker prune if thin pool is exceeded

### DIFF
--- a/lib/fastlane/plugin/mango/helper/docker_commander.rb
+++ b/lib/fastlane/plugin/mango/helper/docker_commander.rb
@@ -48,12 +48,10 @@ module Fastlane
         begin
           block.call
         rescue FastlaneCore::Interface::FastlaneShellError => exception
-          if exception.message =~ /Create more free space in thin pool/
-            retry_counter = retry_counter.to_i + 1
-            if retry_counter < 2
-              prune
-              retry
-            end
+          retry_counter = retry_counter.to_i + 1
+          if exception.message =~ /Create more free space in thin pool/ && retry_counter < 2
+            prune
+            retry
           else
             raise exception
           end

--- a/lib/fastlane/plugin/mango/helper/docker_commander.rb
+++ b/lib/fastlane/plugin/mango/helper/docker_commander.rb
@@ -6,7 +6,7 @@ module Fastlane
     module DockerCommander
 
       def self.pull_image(docker_image_name:)
-        handle_thin_pool_exceptions do
+        handle_thin_pool_exception do
           Actions.sh("docker pull #{docker_image_name}")
         end
       end
@@ -21,7 +21,7 @@ module Fastlane
         # Action.sh returns all output that the command produced but we are only
         # interested in the last line, since it contains the id of the created container.
         UI.important("Attaching #{ENV['PWD']} to the docker container")
-        handle_thin_pool_exceptions do
+        handle_thin_pool_exception do
           Actions.sh("docker run -v $PWD:/root/tests --privileged -t -d #{emulator_args} #{docker_name} #{docker_image}").chomp
         end
       end
@@ -44,7 +44,7 @@ module Fastlane
         Action.sh('docker system prune -f')
       end
 
-      def self.handle_thin_pool_exceptions(&block)
+      def self.handle_thin_pool_exception(&block)
         begin
           block.call
         rescue => exception

--- a/lib/fastlane/plugin/mango/helper/docker_commander.rb
+++ b/lib/fastlane/plugin/mango/helper/docker_commander.rb
@@ -47,10 +47,13 @@ module Fastlane
       def self.handle_thin_pool_exception(&block)
         begin
           block.call
-        rescue => exception
+        rescue FastlaneCore::Interface::FastlaneShellError => exception
           if exception.message =~ /Create more free space in thin pool/
-            prune
-            retry
+            retry_counter = retry_counter.to_i + 1
+            if retry_counter < 2
+              prune
+              retry
+            end
           else
             raise exception
           end

--- a/lib/fastlane/plugin/mango/helper/docker_commander.rb
+++ b/lib/fastlane/plugin/mango/helper/docker_commander.rb
@@ -44,12 +44,12 @@ module Fastlane
         Action.sh('docker system prune -f')
       end
 
-      def handle_thin_pool_exceptions(&block)
+      def self.handle_thin_pool_exceptions(&block)
         begin
           block.call
         rescue => exception
-          if exception.contains?('Create more free space in thin pool')
-            self.prune
+          if exception.message =~ /Create more free space in thin pool/
+            prune
             retry
           else
             raise exception

--- a/spec/docker_commander_spec.rb
+++ b/spec/docker_commander_spec.rb
@@ -79,7 +79,7 @@ describe Fastlane::Helper::DockerCommander do
           Fastlane::Actions.sh('test')
           raise FastlaneCore::Interface::FastlaneShellError, 'Create more free space in thin pool or ...'
         end
-      }.to raise_exception
+      }.to raise_exception(FastlaneCore::Interface::FastlaneShellError)
     end
 
     it 'Calls prune just once when the message is related to thin pool and raise if initial command fails' do
@@ -89,7 +89,7 @@ describe Fastlane::Helper::DockerCommander do
         @docker_commander.handle_thin_pool_exception do
           raise FastlaneCore::Interface::FastlaneShellError, 'Create more free space in thin pool or ...'
         end
-      }.to raise_exception
+      }.to raise_exception(FastlaneCore::Interface::FastlaneShellError)
     end
 
   end

--- a/spec/docker_commander_spec.rb
+++ b/spec/docker_commander_spec.rb
@@ -64,30 +64,36 @@ describe Fastlane::Helper::DockerCommander do
 
   describe '#handle_thin_pool_exception' do
     it 'Raises when exception message is not related to thin pool' do
-      expect(Fastlane::Actions).to receive(:sh).with('docker pull bla').and_raise(FastlaneCore::Interface::FastlaneShellError, 'some message')
       expect {
         @docker_commander.handle_thin_pool_exception do
-          @docker_commander.pull_image(docker_image_name: 'bla')
+          raise FastlaneCore::Interface::FastlaneShellError, 'some message'
         end
       }.to raise_error(FastlaneCore::Interface::FastlaneShellError, 'some message')
     end
 
-    it 'Retries the command when the message is related to thin pool' do
-      expect(Fastlane::Actions).to receive(:sh).twice.with('docker pull bla').and_raise(FastlaneCore::Interface::FastlaneShellError, 'Create more free space in thin pool or ...')
+    it 'Retries the command when the message is related to thin pool and raise if it fails after retry' do
+      expect(Fastlane::Actions).to receive(:sh).twice.with('test')
+
+      expect {
         @docker_commander.handle_thin_pool_exception do
-          @docker_commander.pull_image(docker_image_name: 'bla')
+          Fastlane::Actions.sh('test')
+          raise(FastlaneCore::Interface::FastlaneShellError, 'Create more free space in thin pool or ...')
         end
+      }.to raise_exception
     end
 
-    it 'Calls prune just once when the message is related to thin pool' do
-      expect(Fastlane::Actions).to receive(:sh).twice.with('docker pull bla').and_raise(FastlaneCore::Interface::FastlaneShellError, 'Create more free space in thin pool or ...')
+    it 'Calls prune just once when the message is related to thin pool and raise if initial command fails' do
       expect(@docker_commander).to receive(:prune).once
-      @docker_commander.handle_thin_pool_exception do
-        @docker_commander.pull_image(docker_image_name: 'bla')
-      end
+
+      expect {
+        @docker_commander.handle_thin_pool_exception do
+          raise(FastlaneCore::Interface::FastlaneShellError, 'Create more free space in thin pool or ...')
+        end
+      }.to raise_exception
     end
+
   end
-  
+
   describe '#docker_exec' do
     it 'executes commands inside docker if container name is specified' do
       expect(Fastlane::Actions).to receive(:sh).with("docker exec -i my_container bash -l -c \"do stuff\"")

--- a/spec/docker_commander_spec.rb
+++ b/spec/docker_commander_spec.rb
@@ -77,7 +77,7 @@ describe Fastlane::Helper::DockerCommander do
       expect {
         @docker_commander.handle_thin_pool_exception do
           Fastlane::Actions.sh('test')
-          raise(FastlaneCore::Interface::FastlaneShellError, 'Create more free space in thin pool or ...')
+          raise FastlaneCore::Interface::FastlaneShellError, 'Create more free space in thin pool or ...'
         end
       }.to raise_exception
     end
@@ -87,7 +87,7 @@ describe Fastlane::Helper::DockerCommander do
 
       expect {
         @docker_commander.handle_thin_pool_exception do
-          raise(FastlaneCore::Interface::FastlaneShellError, 'Create more free space in thin pool or ...')
+          raise FastlaneCore::Interface::FastlaneShellError, 'Create more free space in thin pool or ...'
         end
       }.to raise_exception
     end


### PR DESCRIPTION
If we exceed thin pool size, the whole system will be unusable. This PR prunes all the unused container and images if `pull` or `run` commands are getting thin pool exception.

Fixes #20 