### PR TITLE
Fix shell not being ready

### DIFF
--- a/lib/fastlane/plugin/mango/helper/emulator_commander.rb
+++ b/lib/fastlane/plugin/mango/helper/emulator_commander.rb
@@ -17,6 +17,14 @@ module Fastlane
         @docker_commander.exec(command: 'adb shell settings put global window_animation_scale 0.0')
         @docker_commander.exec(command: 'adb shell settings put global transition_animation_scale 0.0')
         @docker_commander.exec(command: 'adb shell settings put global animator_duration_scale 0.0')
+      rescue FastlaneCore::Interface::FastlaneShellError
+        # Under weird circumstances it can happen that adb is running but shell on the emu is not completely up
+        # it recovers after some time, so wait and retry
+        retry_counter = retry_counter.to_i + 1
+        if retry_counter <= 5
+          sleep 10*retry_counter
+          retry
+        end
       end
 
       # Increases logcat storage

--- a/lib/fastlane/plugin/mango/helper/emulator_commander.rb
+++ b/lib/fastlane/plugin/mango/helper/emulator_commander.rb
@@ -17,13 +17,15 @@ module Fastlane
         @docker_commander.exec(command: 'adb shell settings put global window_animation_scale 0.0')
         @docker_commander.exec(command: 'adb shell settings put global transition_animation_scale 0.0')
         @docker_commander.exec(command: 'adb shell settings put global animator_duration_scale 0.0')
-      rescue FastlaneCore::Interface::FastlaneShellError
+      rescue FastlaneCore::Interface::FastlaneShellError => e
         # Under weird circumstances it can happen that adb is running but shell on the emu is not completely up
         # it recovers after some time, so wait and retry
         retry_counter = retry_counter.to_i + 1
         if retry_counter <= 5
           sleep 10*retry_counter
           retry
+        else
+          raise e
         end
       end
 


### PR DESCRIPTION
After we moved direct bash execution to `Actions.sh` we uncovered a problem that was silently suppressed before. Sometimes, if we call `adb shell...` to fast, it will fail because probably it needs some time to startup. 

This PR adds several retries to shell execution.